### PR TITLE
Add guided Three.js learning world

### DIFF
--- a/docs/WORLD_LABS_MARBLE_TEST.md
+++ b/docs/WORLD_LABS_MARBLE_TEST.md
@@ -1,0 +1,33 @@
+# World Labs Marble test
+
+The first test uses `marble-1.0-draft`. It is deliberately teacher-triggered and private.
+
+## Wix page elements
+
+Add these elements to the teacher-only Marble test section:
+
+- `#programmeDropdown`
+- `#subjectInput`
+- `#yearGroupInput`
+- `#topicInput`
+- `#learningAimInput`
+- `#marbleGenerateButton`
+- `#marbleStatusText`
+- `#marblePreviewImage`
+- `#marbleOpenButton`
+
+Copy `wix-backend/iLearn-WorldLabs.web.js` into the Wix backend and the page code from
+`wix-pages/world-labs-marble-test.js` into the page. The existing Wix secret must be
+named exactly `WORLD_LABS_API_KEY`.
+
+The first useful test brief is:
+
+- Programme: Junior Cycle
+- Subject: English
+- Year group: Second Year
+- Topic: A Victorian street for exploring setting, atmosphere and social inequality
+- Learning aim: Identify how physical setting can communicate mood, power and inequality before reading a Victorian novel extract.
+
+The teacher reviews the Marble result before it is attached to a learner pathway. The
+generated SPZ visual world and GLB collider remain separate from the iLEARN route,
+symbol and stopping-point layer.

--- a/src/PathwayV2.tsx
+++ b/src/PathwayV2.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import './ilearn-v2.css'
+import GuidedLearningWorld from './components/GuidedLearningWorld'
 import {
   AgentKernel,
   DEFAULT_AGENT_POLICIES,
@@ -113,6 +114,8 @@ export default function PathwayV2() {
             Prepare governed workflow
           </button>
         </section>
+
+        {immersive && <GuidedLearningWorld />}
 
         <section style={{ marginTop: 28 }} aria-label="Agent pipeline">
           <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'end', marginBottom: 12 }}>

--- a/src/components/GuidedLearningWorld.tsx
+++ b/src/components/GuidedLearningWorld.tsx
@@ -1,0 +1,353 @@
+// @ts-nocheck
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
+
+type RouteName = 'welcome' | 'explore' | 'reflect'
+
+const ROUTES: Record<RouteName, THREE.Vector3[]> = {
+  welcome: [new THREE.Vector3(-6, 0, 4), new THREE.Vector3(-2, 0, 1), new THREE.Vector3(0, 0, -1)],
+  explore: [new THREE.Vector3(-6, 0, 4), new THREE.Vector3(-2, 0, 2), new THREE.Vector3(2, 0, 1), new THREE.Vector3(5, 0, -2)],
+  reflect: [new THREE.Vector3(-6, 0, 4), new THREE.Vector3(-1, 0, 4), new THREE.Vector3(2, 0, 2), new THREE.Vector3(0, 0, -4)],
+}
+
+export default function GuidedLearningWorld() {
+  const mountRef = useRef<HTMLDivElement>(null)
+  const routeApi = useRef<((points: THREE.Vector3[]) => void) | null>(null)
+  const [instruction, setInstruction] = useState('Draw a path on the floor, or choose a guided route.')
+  const [station, setStation] = useState(0)
+
+  useEffect(() => {
+    const mount = mountRef.current
+    if (!mount) return
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color('#07121a')
+    scene.fog = new THREE.FogExp2('#07121a', 0.035)
+
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100)
+    camera.position.set(0, 11, 15)
+    camera.lookAt(0, 0, 0)
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75))
+    renderer.outputColorSpace = THREE.SRGBColorSpace
+    renderer.shadowMap.enabled = !reduceMotion
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap
+    renderer.domElement.setAttribute('aria-label', 'Interactive guided learning world. Draw a route for the learner avatar.')
+    renderer.domElement.style.cssText = 'width:100%;height:100%;display:block;touch-action:none;cursor:crosshair'
+    mount.appendChild(renderer.domElement)
+
+    scene.add(new THREE.HemisphereLight('#b8e8ff', '#13231d', 2.2))
+    const key = new THREE.DirectionalLight('#fff2c7', 3.5)
+    key.position.set(5, 12, 7)
+    key.castShadow = !reduceMotion
+    scene.add(key)
+
+    const floor = new THREE.Mesh(
+      new THREE.CircleGeometry(13, 64),
+      new THREE.MeshStandardMaterial({ color: '#10262a', roughness: 0.78, metalness: 0.08 }),
+    )
+    floor.rotation.x = -Math.PI / 2
+    floor.receiveShadow = true
+    scene.add(floor)
+
+    const grid = new THREE.GridHelper(22, 22, '#346b68', '#173938')
+    grid.position.y = 0.012
+    scene.add(grid)
+
+    const stations = [
+      { n: 1, label: 'START', position: new THREE.Vector3(-6, 0, 4), colour: '#67e8c2' },
+      { n: 2, label: 'EXPLORE', position: new THREE.Vector3(5, 0, -2), colour: '#74b9ff' },
+      { n: 3, label: 'REFLECT', position: new THREE.Vector3(0, 0, -4), colour: '#f2c879' },
+    ]
+
+    const makeLabel = (text: string, colour: string) => {
+      const canvas = document.createElement('canvas')
+      canvas.width = 512
+      canvas.height = 160
+      const ctx = canvas.getContext('2d')!
+      ctx.fillStyle = 'rgba(4,12,18,.88)'
+      ctx.roundRect(8, 8, 496, 144, 30)
+      ctx.fill()
+      ctx.strokeStyle = colour
+      ctx.lineWidth = 7
+      ctx.stroke()
+      ctx.fillStyle = '#ffffff'
+      ctx.font = '800 48px Inter, sans-serif'
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText(text, 256, 82)
+      const texture = new THREE.CanvasTexture(canvas)
+      texture.colorSpace = THREE.SRGBColorSpace
+      const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: texture, transparent: true }))
+      sprite.scale.set(4.5, 1.4, 1)
+      return sprite
+    }
+
+    stations.forEach(({ n, label, position, colour }) => {
+      const group = new THREE.Group()
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(0.72, 1.02, 48),
+        new THREE.MeshBasicMaterial({ color: colour, transparent: true, opacity: 0.9, side: THREE.DoubleSide }),
+      )
+      ring.rotation.x = -Math.PI / 2
+      ring.position.y = 0.03
+      group.add(ring)
+      const stop = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.44, 0.44, 0.08, 32),
+        new THREE.MeshStandardMaterial({ color: colour, emissive: colour, emissiveIntensity: 0.38 }),
+      )
+      stop.position.y = 0.04
+      group.add(stop)
+      const labelSprite = makeLabel(`${n} · ${label}`, colour)
+      labelSprite.position.y = 2.1
+      group.add(labelSprite)
+      group.position.copy(position)
+      scene.add(group)
+    })
+
+    const avatar = new THREE.Group()
+    avatar.position.copy(stations[0].position)
+    const bodyMaterial = new THREE.MeshStandardMaterial({ color: '#e7f5ee', roughness: 0.68 })
+    const accentMaterial = new THREE.MeshStandardMaterial({ color: '#53d3ad', roughness: 0.55 })
+    const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.46, 1.05, 8, 16), bodyMaterial)
+    body.position.y = 1.48
+    body.castShadow = true
+    avatar.add(body)
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.43, 24, 18), bodyMaterial)
+    head.position.y = 2.62
+    head.castShadow = true
+    avatar.add(head)
+
+    const makeLimb = (x: number, y: number, length: number, material: THREE.Material) => {
+      const pivot = new THREE.Group()
+      pivot.position.set(x, y, 0)
+      const limb = new THREE.Mesh(new THREE.CapsuleGeometry(0.12, length, 6, 10), material)
+      limb.position.y = -length * 0.5
+      limb.castShadow = true
+      pivot.add(limb)
+      avatar.add(pivot)
+      return pivot
+    }
+
+    // Arms begin in a relaxed, slightly bent-looking pose and swing opposite the legs.
+    const leftArm = makeLimb(-0.58, 1.94, 0.82, accentMaterial)
+    const rightArm = makeLimb(0.58, 1.94, 0.82, accentMaterial)
+    leftArm.rotation.z = -0.17
+    rightArm.rotation.z = 0.17
+    leftArm.rotation.x = 0.12
+    rightArm.rotation.x = -0.12
+    const leftLeg = makeLimb(-0.25, 0.96, 0.82, bodyMaterial)
+    const rightLeg = makeLimb(0.25, 0.96, 0.82, bodyMaterial)
+    scene.add(avatar)
+
+    const raycaster = new THREE.Raycaster()
+    const pointer = new THREE.Vector2()
+    const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0)
+    let drawing = false
+    let drawPoints: THREE.Vector3[] = []
+    let preview: THREE.Line | null = null
+    let activeLine: THREE.Line | null = null
+    let activeCurve: THREE.CatmullRomCurve3 | null = null
+    let travelled = 0
+    let totalLength = 0
+    let lastTime = performance.now()
+    let disposed = false
+
+    const pointFromEvent = (event: PointerEvent) => {
+      const rect = renderer.domElement.getBoundingClientRect()
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+      raycaster.setFromCamera(pointer, camera)
+      const target = new THREE.Vector3()
+      return raycaster.ray.intersectPlane(plane, target) ? target : null
+    }
+
+    const makeRouteLine = (points: THREE.Vector3[], colour = '#65f2ca') => {
+      const curve = new THREE.CatmullRomCurve3(points)
+      const sampled = curve.getPoints(Math.max(32, points.length * 18)).map((point) => point.clone().setY(0.08))
+      const geometry = new THREE.BufferGeometry().setFromPoints(sampled)
+      const material = new THREE.LineBasicMaterial({ color: colour, transparent: true, opacity: 0.95 })
+      return { curve, line: new THREE.Line(geometry, material) }
+    }
+
+    const beginRoute = (points: THREE.Vector3[]) => {
+      if (points.length < 2) return
+      if (activeLine) {
+        scene.remove(activeLine)
+        activeLine.geometry.dispose()
+        ;(activeLine.material as THREE.Material).dispose()
+      }
+      const route = makeRouteLine(points)
+      activeCurve = route.curve
+      activeLine = route.line
+      scene.add(activeLine)
+      travelled = 0
+      totalLength = activeCurve.getLength()
+      setInstruction(reduceMotion ? 'Route selected. Use the station buttons to move step by step.' : 'Follow the glowing line. Stop at each numbered station.')
+    }
+    routeApi.current = beginRoute
+
+    const onPointerDown = (event: PointerEvent) => {
+      const point = pointFromEvent(event)
+      if (!point) return
+      renderer.domElement.setPointerCapture(event.pointerId)
+      drawing = true
+      drawPoints = [point]
+      setInstruction('Keep drawing the route. Release to begin walking.')
+    }
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!drawing) return
+      const point = pointFromEvent(event)
+      if (!point) return
+      const previous = drawPoints[drawPoints.length - 1]
+      if (previous.distanceTo(point) < 0.28) return
+      drawPoints.push(point)
+      if (preview) {
+        scene.remove(preview)
+        preview.geometry.dispose()
+        ;(preview.material as THREE.Material).dispose()
+      }
+      preview = makeRouteLine(drawPoints, '#d8f9ee').line
+      scene.add(preview)
+    }
+
+    const onPointerUp = () => {
+      if (!drawing) return
+      drawing = false
+      if (preview) {
+        scene.remove(preview)
+        preview.geometry.dispose()
+        ;(preview.material as THREE.Material).dispose()
+        preview = null
+      }
+      if (drawPoints.length >= 3) beginRoute(drawPoints)
+      else setInstruction('That path was too short. Draw a longer route.')
+    }
+
+    renderer.domElement.addEventListener('pointerdown', onPointerDown)
+    renderer.domElement.addEventListener('pointermove', onPointerMove)
+    renderer.domElement.addEventListener('pointerup', onPointerUp)
+    renderer.domElement.addEventListener('pointercancel', onPointerUp)
+
+    const resize = () => {
+      const width = Math.max(1, mount.clientWidth)
+      const height = Math.max(1, mount.clientHeight)
+      renderer.setSize(width, height, false)
+      camera.aspect = width / height
+      camera.updateProjectionMatrix()
+    }
+    const observer = new ResizeObserver(resize)
+    observer.observe(mount)
+    resize()
+
+    const clock = new THREE.Clock()
+    const animate = (now: number) => {
+      if (disposed) return
+      requestAnimationFrame(animate)
+      const delta = Math.min((now - lastTime) / 1000, 0.05)
+      lastTime = now
+      const elapsed = clock.getElapsedTime()
+
+      if (activeCurve && !reduceMotion && travelled < totalLength) {
+        travelled = Math.min(totalLength, travelled + delta * 2.25)
+        const u = totalLength ? travelled / totalLength : 1
+        const position = activeCurve.getPointAt(u)
+        const tangent = activeCurve.getTangentAt(Math.min(0.999, u))
+        avatar.position.copy(position)
+        avatar.rotation.y = Math.atan2(tangent.x, tangent.z)
+        const stride = Math.sin(elapsed * 8) * 0.48
+        leftArm.rotation.x = 0.12 + stride
+        rightArm.rotation.x = -0.12 - stride
+        leftLeg.rotation.x = -stride * 0.82
+        rightLeg.rotation.x = stride * 0.82
+        body.position.y = 1.48 + Math.abs(Math.sin(elapsed * 8)) * 0.055
+
+        stations.forEach((item, index) => {
+          if (position.distanceTo(item.position) < 1.05 && station !== index + 1) {
+            setStation(index + 1)
+            setInstruction(`Stop ${index + 1}: ${item.label}. Complete this learning step before continuing.`)
+          }
+        })
+
+        if (u >= 1) {
+          leftArm.rotation.x = 0.12
+          rightArm.rotation.x = -0.12
+          leftLeg.rotation.x = 0
+          rightLeg.rotation.x = 0
+          setInstruction('Route complete. Choose another route or draw your own.')
+        }
+      }
+
+      renderer.render(scene, camera)
+    }
+    requestAnimationFrame(animate)
+
+    return () => {
+      disposed = true
+      observer.disconnect()
+      routeApi.current = null
+      renderer.domElement.removeEventListener('pointerdown', onPointerDown)
+      renderer.domElement.removeEventListener('pointermove', onPointerMove)
+      renderer.domElement.removeEventListener('pointerup', onPointerUp)
+      renderer.domElement.removeEventListener('pointercancel', onPointerUp)
+      scene.traverse((object: any) => {
+        object.geometry?.dispose?.()
+        if (Array.isArray(object.material)) object.material.forEach((material: THREE.Material) => material.dispose())
+        else object.material?.dispose?.()
+      })
+      renderer.dispose()
+      renderer.domElement.remove()
+    }
+  }, [])
+
+  const chooseRoute = (name: RouteName) => {
+    routeApi.current?.(ROUTES[name].map((point) => point.clone()))
+    setStation(0)
+  }
+
+  return (
+    <section
+      aria-labelledby="guided-world-title"
+      style={{
+        marginTop: 28,
+        border: '1px solid rgba(103,232,194,.3)',
+        borderRadius: 22,
+        overflow: 'hidden',
+        background: '#07121a',
+        boxShadow: '0 24px 80px rgba(0,0,0,.35)',
+      }}
+    >
+      <div style={{ padding: '18px 18px 14px', display: 'flex', gap: 16, alignItems: 'start', justifyContent: 'space-between', flexWrap: 'wrap' }}>
+        <div>
+          <p style={{ color: '#67e8c2', fontSize: 10, letterSpacing: '.16em', margin: 0 }}>GUIDED LEARNING WORLD</p>
+          <h2 id="guided-world-title" style={{ fontFamily: 'Georgia, serif', fontSize: 29, margin: '6px 0' }}>See where to go. Know when to stop.</h2>
+          <p aria-live="polite" style={{ color: '#b9cac6', margin: 0, maxWidth: 680 }}>{instruction}</p>
+        </div>
+        <span style={{ border: '1px solid rgba(255,255,255,.14)', borderRadius: 999, padding: '8px 12px', color: '#dff8f0', fontSize: 12 }}>
+          {station ? `At station ${station}` : 'Ready'}
+        </span>
+      </div>
+
+      <div ref={mountRef} style={{ height: 'clamp(360px,58vw,620px)', position: 'relative' }} />
+
+      <nav aria-label="Guided routes" style={{ padding: 14, display: 'flex', gap: 9, flexWrap: 'wrap', borderTop: '1px solid rgba(255,255,255,.08)' }}>
+        <button onClick={() => chooseRoute('welcome')} style={routeButton}>1 · Start route</button>
+        <button onClick={() => chooseRoute('explore')} style={routeButton}>2 · Explore route</button>
+        <button onClick={() => chooseRoute('reflect')} style={routeButton}>3 · Reflect route</button>
+      </nav>
+    </section>
+  )
+}
+
+const routeButton: React.CSSProperties = {
+  border: '1px solid rgba(103,232,194,.34)',
+  borderRadius: 999,
+  padding: '10px 15px',
+  color: '#eafff8',
+  background: 'rgba(103,232,194,.1)',
+  fontWeight: 800,
+  cursor: 'pointer',
+}

--- a/wix-backend/iLearn-WorldLabs.web.js
+++ b/wix-backend/iLearn-WorldLabs.web.js
@@ -1,0 +1,184 @@
+import { Permissions, webMethod } from "wix-web-module";
+import { fetch } from "wix-fetch";
+import { getSecret } from "wix-secrets-backend";
+import { currentMember } from "wix-members-backend";
+
+const WORLD_LABS_API = "https://api.worldlabs.ai/marble/v1";
+const DEFAULT_MODEL = "marble-1.0-draft";
+const ALLOWED_MODELS = new Set([
+  "marble-1.0-draft",
+  "marble-1.1",
+  "marble-1.1-plus"
+]);
+
+/**
+ * Starts a private Marble generation. The teacher must explicitly request this;
+ * pathway creation never spends World Labs credits automatically.
+ */
+export const startEducationalWorld = webMethod(
+  Permissions.SiteMember,
+  async (rawBrief) => {
+    const member = await requireMember();
+    const brief = prepareBrief(rawBrief);
+    const apiKey = await requireApiKey();
+
+    const response = await fetch(`${WORLD_LABS_API}/worlds:generate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "WLT-Api-Key": apiKey
+      },
+      body: JSON.stringify({
+        display_name: brief.displayName,
+        model: brief.model,
+        tags: ["ilearn", "education", brief.programmeTag],
+        permission: {
+          public: false,
+          allow_id_access: false,
+          allowed_readers: [],
+          allowed_writers: []
+        },
+        world_prompt: {
+          type: "text",
+          disable_recaption: false,
+          text_prompt: buildWorldPrompt(brief)
+        }
+      })
+    });
+
+    const data = await readWorldLabsResponse(response, "start world generation");
+    if (!data?.operation_id) throw new Error("World Labs returned no operation ID.");
+
+    return {
+      operationId: data.operation_id,
+      done: Boolean(data.done),
+      status: data.metadata?.progress?.status || "QUEUED",
+      description: data.metadata?.progress?.description || "World generation queued",
+      requestedBy: member._id,
+      model: brief.model,
+      estimatedCredits: brief.model === "marble-1.0-draft" ? 230 : 1580
+    };
+  }
+);
+
+/** Polls a generation and returns only the public-safe world fields needed by iLEARN. */
+export const getEducationalWorldStatus = webMethod(
+  Permissions.SiteMember,
+  async (operationId) => {
+    await requireMember();
+    const safeOperationId = validateId(operationId, "operation ID");
+    const apiKey = await requireApiKey();
+    const response = await fetch(
+      `${WORLD_LABS_API}/operations/${encodeURIComponent(safeOperationId)}`,
+      { headers: { "WLT-Api-Key": apiKey } }
+    );
+    const data = await readWorldLabsResponse(response, "check world generation");
+
+    if (data.error) {
+      return {
+        operationId: safeOperationId,
+        done: true,
+        status: "FAILED",
+        description: data.error.message || "World generation failed."
+      };
+    }
+
+    const world = data.done ? toSafeWorld(data.response) : null;
+    return {
+      operationId: safeOperationId,
+      done: Boolean(data.done),
+      status: data.metadata?.progress?.status || (data.done ? "SUCCEEDED" : "IN_PROGRESS"),
+      description: data.metadata?.progress?.description || "World generation in progress",
+      progress: data.metadata?.progress?.percentage || null,
+      world
+    };
+  }
+);
+
+function prepareBrief(raw = {}) {
+  const programme = cleanText(raw.programme, 80) || "Irish secondary education";
+  const subject = cleanText(raw.subject, 80) || "English";
+  const yearGroup = cleanText(raw.yearGroup, 60) || "secondary school";
+  const topic = cleanText(raw.topic, 180);
+  const learningAim = cleanText(raw.learningAim || raw.teacherIntent, 500);
+  if (!topic) throw new Error("Add a topic before generating a world.");
+  if (!learningAim) throw new Error("Add the intended learning before generating a world.");
+
+  const requestedModel = cleanText(raw.model, 40) || DEFAULT_MODEL;
+  if (!ALLOWED_MODELS.has(requestedModel)) throw new Error("Unsupported Marble model.");
+
+  return {
+    programme,
+    subject,
+    yearGroup,
+    topic,
+    learningAim,
+    model: requestedModel,
+    displayName: cleanText(raw.displayName, 64) || `iLEARN · ${topic}`.slice(0, 64),
+    programmeTag: programme.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 32) || "secondary"
+  };
+}
+
+function buildWorldPrompt(brief) {
+  return [
+    `Create a realistic, coherent, navigable educational environment for ${brief.programme}, ${brief.subject}, ${brief.yearGroup}.`,
+    `Topic: ${brief.topic}.`,
+    `Learning purpose: ${brief.learningAim}.`,
+    "Design one clear walking route with three visually distinct stopping areas: orientation, exploration, and reflection.",
+    "Keep the main route wide, level, uncluttered, and readable. Include calm lighting, strong visual landmarks, predictable sight lines, and quiet pause spaces.",
+    "Do not include written labels, floating text, UI, crowds, hazards, weapons, frightening imagery, flashing lights, or sensory overload.",
+    "Leave open floor space at each stop so iLEARN can add accessible symbols, task markers, and an avatar navigation layer later.",
+    "Use historically and culturally appropriate architecture where the topic calls for it. Do not invent factual displays or quotations."
+  ].join(" ");
+}
+
+function toSafeWorld(world) {
+  if (!world) return null;
+  const id = world.id || world.world_id || "";
+  return {
+    id,
+    displayName: world.display_name || "iLEARN world",
+    marbleUrl: world.world_marble_url || (id ? `https://marble.worldlabs.ai/world/${id}` : ""),
+    caption: world.assets?.caption || "",
+    thumbnailUrl: world.assets?.thumbnail_url || "",
+    panoramaUrl: world.assets?.imagery?.pano_url || "",
+    colliderMeshUrl: world.assets?.mesh?.collider_mesh_url || "",
+    splat100kUrl: world.assets?.splats?.spz_urls?.["100k"] || "",
+    splat500kUrl: world.assets?.splats?.spz_urls?.["500k"] || ""
+  };
+}
+
+async function requireMember() {
+  const member = await currentMember.getMember();
+  if (!member?._id) throw new Error("Sign in to generate an educational world.");
+  return member;
+}
+
+async function requireApiKey() {
+  const apiKey = await getSecret("WORLD_LABS_API_KEY");
+  if (!apiKey) throw new Error("WORLD_LABS_API_KEY is not configured.");
+  return apiKey;
+}
+
+async function readWorldLabsResponse(response, action) {
+  let data = {};
+  try {
+    data = await response.json();
+  } catch (_) {
+    // Use the status-specific error below when the provider returned no JSON.
+  }
+  if (response.ok) return data;
+  if (response.status === 402) throw new Error("World Labs API credits are insufficient.");
+  if (response.status === 429) throw new Error("World Labs is busy. Wait a minute and try again.");
+  throw new Error(data?.detail || data?.message || `Could not ${action} (${response.status}).`);
+}
+
+function validateId(value, label) {
+  const clean = String(value || "").trim();
+  if (!/^[a-zA-Z0-9-]{8,80}$/.test(clean)) throw new Error(`Invalid ${label}.`);
+  return clean;
+}
+
+function cleanText(value, maxLength) {
+  return String(value || "").replace(/[<>\u0000-\u001f]/g, " ").replace(/\s+/g, " ").trim().slice(0, maxLength);
+}

--- a/wix-pages/world-labs-marble-test.js
+++ b/wix-pages/world-labs-marble-test.js
@@ -1,0 +1,72 @@
+import {
+  startEducationalWorld,
+  getEducationalWorldStatus
+} from "backend/iLearn-WorldLabs.web";
+
+const POLL_MS = 10000;
+const MAX_POLLS = 48;
+
+$w.onReady(() => {
+  $w("#marbleStatusText").text = "Ready to create a private draft world.";
+  $w("#marblePreviewImage").hide();
+  $w("#marbleOpenButton").hide();
+  $w("#marbleGenerateButton").onClick(generateWorld);
+});
+
+async function generateWorld() {
+  setBusy(true);
+  try {
+    const started = await startEducationalWorld({
+      programme: $w("#programmeDropdown").value,
+      subject: $w("#subjectInput").value,
+      yearGroup: $w("#yearGroupInput").value,
+      topic: $w("#topicInput").value,
+      learningAim: $w("#learningAimInput").value,
+      model: "marble-1.0-draft"
+    });
+    $w("#marbleStatusText").text = "World generation started. This draft normally takes about 20 seconds.";
+    await pollUntilDone(started.operationId);
+  } catch (error) {
+    $w("#marbleStatusText").text = error?.message || "The world could not be generated.";
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function pollUntilDone(operationId) {
+  for (let attempt = 0; attempt < MAX_POLLS; attempt += 1) {
+    const result = await getEducationalWorldStatus(operationId);
+    $w("#marbleStatusText").text = result.description || "Building the world…";
+    if (result.done) {
+      if (result.status !== "SUCCEEDED" || !result.world) {
+        throw new Error(result.description || "World generation failed.");
+      }
+      showWorld(result.world);
+      return;
+    }
+    await wait(POLL_MS);
+  }
+  throw new Error("The world is still processing. Try checking again shortly.");
+}
+
+function showWorld(world) {
+  $w("#marbleStatusText").text = "Draft world ready. Review it before using it with learners.";
+  if (world.thumbnailUrl) {
+    $w("#marblePreviewImage").src = world.thumbnailUrl;
+    $w("#marblePreviewImage").show();
+  }
+  if (world.marbleUrl) {
+    $w("#marbleOpenButton").link = world.marbleUrl;
+    $w("#marbleOpenButton").target = "_blank";
+    $w("#marbleOpenButton").show();
+  }
+}
+
+function setBusy(busy) {
+  if (busy) $w("#marbleGenerateButton").disable();
+  else $w("#marbleGenerateButton").enable();
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## What changed

- Added a Three.js guided learning world inspired by the path-drawing architecture in `achrefelouafi/AvatarCastingAbilitiesThreeJS`.
- Added draw-to-walk routing with Catmull–Rom curves.
- Added three numbered learning stations with visible stop markers.
- Added preset Start, Explore and Reflect routes for learners who do not want to draw.
- Added a simple articulated learner avatar with relaxed arms and opposite arm/leg walking motion.
- Added touch input, responsive canvas sizing, screen-reader status updates and reduced-motion handling.
- Connected the world to the existing **Include interactive / immersive treatment** teacher choice.

## Product impact

The teacher still decides whether an immersive treatment is justified. The feature does not bypass the curriculum, quality or teacher-approval stages.

## Validation

- `npm run build` passes.
- Existing project warnings remain: three generated CSS optimizer warnings and one bundle-size warning.
- `npm ci` is currently blocked by the repository's pre-existing package-lock mismatch, so validation used `npm install --package-lock=false` followed by the production build.

## Source note

The implementation reuses the public repository's interaction concepts, not its bundled avatar or HDR assets. This avoids importing assets with separate licence terms.