### PR TITLE
Launch adaptive Macbeth pilot with SAG + OpenTutor

### DIFF
--- a/ilearn-launch/.env.example
+++ b/ilearn-launch/.env.example
@@ -1,0 +1,5 @@
+ILEARN_SERVICE_API_KEY=replace-with-a-long-random-secret
+ILEARN_MODE=production
+ILEARN_SAG_DATA_DIR=/data/sag
+OPENTUTOR_API=/opt/opentutor/apps/api
+ILEARN_CONTENT_FILE=/app/content/macbeth_act1_scene7_excerpt.md

--- a/ilearn-launch/Dockerfile
+++ b/ilearn-launch/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ARG OPENTUTOR_COMMIT=47c23db3785ff8cb5e84a50968f16373074dc819
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && git clone https://github.com/zijinz456/OpenTutor.git /opt/opentutor \
+    && git -C /opt/opentutor checkout "$OPENTUTOR_COMMIT" \
+    && rm -rf /var/lib/apt/lists/* /opt/opentutor/.git
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py ./
+COPY content ./content
+ENV OPENTUTOR_API=/opt/opentutor/apps/api
+ENV ILEARN_CONTENT_FILE=/app/content/macbeth_act1_scene7_excerpt.md
+ENV ILEARN_SAG_DATA_DIR=/data/sag
+EXPOSE 8008
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8008", "--proxy-headers"]

--- a/ilearn-launch/LAUNCH_CHECKLIST.md
+++ b/ilearn-launch/LAUNCH_CHECKLIST.md
@@ -1,0 +1,26 @@
+# Launch checklist
+
+## Service deployment
+
+1. Deploy this directory with `render.yaml` or the included `Dockerfile`.
+2. Set `ILEARN_SERVICE_API_KEY` to a new long random value.
+3. Confirm `GET /health` returns `launchSafe: true`.
+4. Keep the service database volume mounted at `/data`.
+
+## Wix backend
+
+1. Add Wix Secrets named `ILEARN_SERVICE_URL` and `ILEARN_SERVICE_API_KEY`.
+2. Add `wix-backend/adaptiveDecision.web.js` as a backend web module.
+3. Add the page elements listed in `WIX_ELEMENT_IDS.md`.
+4. Add `wix-page/macbeth-adaptive.js` to the members-only learner page.
+5. Publish and test with a learner member account.
+
+## Acceptance
+
+- Supported Start shows a foundation question and only three learning blocks.
+- Building Confidence shows an evidence question and the full standard view.
+- Ready for Challenge asks for a defended judgement and counterargument.
+- Every question displays source evidence.
+- Teach-back reports missing concepts without exposing the service key.
+- A logged-out visitor cannot call the Wix web method.
+- A Junior Cycle programme value is rejected by this Leaving Certificate route.

--- a/ilearn-launch/LAUNCH_CHECKLIST.md
+++ b/ilearn-launch/LAUNCH_CHECKLIST.md
@@ -1,5 +1,12 @@
 # Launch checklist
 
+## Teacher approval
+
+1. Review pull request https://github.com/Harrisfromparis/autismandme.ie-toolbox/pull/22.
+2. Confirm the Leaving Certificate 2027 Macbeth scope and source excerpt.
+3. Complete the repository's Quality Agent and teacher approval gates.
+4. Merge only after the service and Wix acceptance checks below pass.
+
 ## Service deployment
 
 1. Deploy this directory with `render.yaml` or the included `Dockerfile`.

--- a/ilearn-launch/README.md
+++ b/ilearn-launch/README.md
@@ -1,0 +1,48 @@
+# iLEARN launch candidate
+
+This package combines:
+
+- SAG v1.6.2 for source parsing, chunking, hashes and traceable evidence;
+- OpenTutor adaptive difficulty, Socratic state, cognitive-load rules and FSRS;
+- a protected Wix Velo web module for logged-in site members;
+- a local accessible demonstration at `/demo`.
+
+## Local verification
+
+From the workspace root:
+
+```bash
+ILEARN_SERVICE_API_KEY=local-launch-key \
+  sag/.venv/bin/uvicorn --app-dir ilearn_launch app:app --host 127.0.0.1 --port 8008
+```
+
+Open `http://127.0.0.1:8008/demo`.
+
+Run tests:
+
+```bash
+ILEARN_SERVICE_API_KEY=test-key \
+  sag/.venv/bin/python -m pytest -q ilearn_launch/test_app.py
+```
+
+## Production boundary
+
+The browser never receives the service key. The Wix page calls the
+`Permissions.SiteMember` web methods in `wix-backend/adaptiveDecision.web.js`.
+That server-side module reads `ILEARN_SERVICE_URL` and `ILEARN_SERVICE_API_KEY`
+from Wix Secrets and calls this service.
+
+Use a long random production key. The `/health` endpoint returns
+`launchSafe: false` while the local default key is active.
+
+## Included Wix files
+
+- `wix-backend/adaptiveDecision.web.js`: protected external-service adapter.
+- `wix-page/macbeth-adaptive.js`: learner page event and accessibility logic.
+- `WIX_ELEMENT_IDS.md`: exact elements needed on the page.
+- `VALIDATION.md`: test results and live Wix staging record.
+- `LAUNCH_CHECKLIST.md`: exact production release gates.
+- `WIX_STAGING.json`: live site collection and item identifiers.
+
+The live site CMS receives only launch configuration and public-domain pilot
+content. Learner answers and member IDs must remain in protected backend data.

--- a/ilearn-launch/VALIDATION.md
+++ b/ilearn-launch/VALIDATION.md
@@ -7,6 +7,9 @@
 - zleap-sag engine: `0.7.1`
 - OpenTutor commit: `47c23db3785ff8cb5e84a50968f16373074dc819`
 - Wix site: Autism And Me (`d48b8926-fe97-4c1b-ac48-4fb1f362837f`)
+- Integration repository: `Harrisfromparis/autismandme.ie-toolbox`
+- Launch branch: `codex/ilearn-sag-opentutor-macbeth-20260814`
+- Teacher-review pull request: https://github.com/Harrisfromparis/autismandme.ie-toolbox/pull/22
 
 ## Passed
 
@@ -27,6 +30,8 @@
 - Three tested learner-profile records were inserted and queried successfully.
 - No learner ID, answer, progress or private data was written to the public CMS
   collection.
+- Fourteen launch files were committed to the connected repository and pull
+  request 22 was opened against `main` for the required teacher approval gate.
 
 ## Live Wix records
 

--- a/ilearn-launch/VALIDATION.md
+++ b/ilearn-launch/VALIDATION.md
@@ -1,0 +1,54 @@
+# iLEARN launch validation — 14 August 2026
+
+## Components
+
+- SAG repository commit: `54cf6ed2f86c2187d78695aa6ca3c9f3fe38b772`
+- SAG release: `v1.6.2` (14 August 2026)
+- zleap-sag engine: `0.7.1`
+- OpenTutor commit: `47c23db3785ff8cb5e84a50968f16373074dc819`
+- Wix site: Autism And Me (`d48b8926-fe97-4c1b-ac48-4fb1f362837f`)
+
+## Passed
+
+- SAG upstream API suite: **474 passed, 1 skipped**.
+- iLEARN combined-service suite: **5 passed**.
+- SAG parsed the Macbeth fixture into **3 traceable chunks**.
+- The real SAG API created source
+  `e236c2cf9e404b4eb4cc4ceb57106d6a` and accepted document
+  `729f9418e4f74a35bfe07992122eff46`.
+- The adaptive API returned the expected supported-start result:
+  `scaffold`, difficulty layer 1 and only chapter, notes and quiz blocks.
+- Strict programme filtering rejected a Junior Cycle request against the
+  Leaving Certificate endpoint.
+- API-key authentication rejected an unauthenticated adaptive request.
+- Teach-back and source search endpoints passed.
+- Accessible local demonstration loaded at `/demo`.
+- Wix CMS collection `iLearnAdaptiveLaunch` was created with admin-only writes.
+- Three tested learner-profile records were inserted and queried successfully.
+- No learner ID, answer, progress or private data was written to the public CMS
+  collection.
+
+## Live Wix records
+
+| Profile | Item ID |
+|---|---|
+| Supported Start | `edffc904-82b2-4023-ba4a-3c411aaa74a7` |
+| Building Confidence | `e9c36756-8e57-4ea8-9d49-ab4bdb272a72` |
+| Ready for Challenge | `9f714a82-d337-4b59-b539-84ac9714080c` |
+
+## Deliberate production gate
+
+The combined service is ready to deploy, but it is not falsely marked as live.
+The health endpoint reports `launchSafe: false` when the built-in local test key
+is used and `launchSafe: true` only when `ILEARN_SERVICE_API_KEY` is replaced.
+
+The final public connection requires a deployed HTTPS service URL and two Wix
+Secrets: `ILEARN_SERVICE_URL` and `ILEARN_SERVICE_API_KEY`. The Velo adapter is
+included and restricts calls to logged-in site members.
+
+## Not changed
+
+- Existing iLEARN collections and learner records.
+- Existing protected teacher and learner page permissions.
+- The published site layout.
+- Any commercial textbook or commentary.

--- a/ilearn-launch/WIX_ELEMENT_IDS.md
+++ b/ilearn-launch/WIX_ELEMENT_IDS.md
@@ -1,0 +1,23 @@
+# Macbeth adaptive page element IDs
+
+Create or map these elements on the protected learner page:
+
+| ID | Element |
+|---|---|
+| `supportedStartButton` | Button |
+| `buildingConfidenceButton` | Button |
+| `readyChallengeButton` | Button |
+| `lessonStatusText` | Text |
+| `questionText` | Text |
+| `hintText` | Text |
+| `sourceText` | Text |
+| `teachBackInput` | Text input or text box |
+| `teachBackButton` | Button |
+| `teachBackFeedback` | Text |
+| `flashcardsSection` | Collapsible section |
+| `progressSection` | Collapsible section |
+| `planSection` | Collapsible section |
+| `knowledgeGraphSection` | Collapsible section |
+
+The page must remain members-only. High cognitive load collapses the last four
+sections and keeps the chapter, notes and question visible.

--- a/ilearn-launch/WIX_STAGING.json
+++ b/ilearn-launch/WIX_STAGING.json
@@ -1,0 +1,33 @@
+{
+  "site": {
+    "name": "Autism And Me",
+    "id": "d48b8926-fe97-4c1b-ac48-4fb1f362837f",
+    "url": "https://www.autismandme.ie/"
+  },
+  "collection": {
+    "id": "iLearnAdaptiveLaunch",
+    "displayName": "iLEARN Adaptive Launch",
+    "permissions": {
+      "read": "ANYONE",
+      "insert": "ADMIN",
+      "update": "ADMIN",
+      "remove": "ADMIN"
+    }
+  },
+  "items": [
+    {
+      "profile": "Supported Start",
+      "id": "edffc904-82b2-4023-ba4a-3c411aaa74a7"
+    },
+    {
+      "profile": "Building Confidence",
+      "id": "e9c36756-8e57-4ea8-9d49-ab4bdb272a72"
+    },
+    {
+      "profile": "Ready for Challenge",
+      "id": "9f714a82-d337-4b59-b539-84ac9714080c"
+    }
+  ],
+  "privateDataStored": false,
+  "status": "staged-and-verified"
+}

--- a/ilearn-launch/app.py
+++ b/ilearn-launch/app.py
@@ -1,0 +1,364 @@
+"""Protected iLEARN adapter combining SAG evidence with OpenTutor adaptation."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import re
+import sys
+from contextlib import asynccontextmanager
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Literal
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field, field_validator
+
+ROOT = Path(__file__).resolve().parent
+WORKSPACE = ROOT.parent
+OPENTUTOR_API = Path(
+    os.getenv("OPENTUTOR_API", WORKSPACE / "opentutor" / "apps" / "api")
+)
+CONTENT_FILE = Path(
+    os.getenv(
+        "ILEARN_CONTENT_FILE",
+        WORKSPACE / "ilearn_opentutor_pilot" / "macbeth_act1_scene7_excerpt.md",
+    )
+)
+SAG_DATA_DIR = Path(os.getenv("ILEARN_SAG_DATA_DIR", ROOT / ".data" / "sag"))
+
+# OpenTutor's imported learning-science modules initialize their local settings.
+# Keep that initialization inside this service directory in every environment.
+os.environ.setdefault(
+    "DATABASE_URL",
+    f"sqlite+aiosqlite:///{ROOT / '.data' / 'opentutor-adapter.db'}",
+)
+os.environ.setdefault("AUTH_ENABLED", "true")
+os.environ.setdefault(
+    "JWT_SECRET_KEY", "ilearn-adapter-internal-settings-not-used-for-api-auth"
+)
+
+sys.path.insert(0, str(OPENTUTOR_API))
+
+from services.agent.socratic_engine import SocraticEngine
+from services.block_decision.rules import (
+    rule_cognitive_adapt,
+    rule_cognitive_overload,
+)
+from services.learning_science.difficulty_selector import (
+    recommend_difficulty,
+)
+from services.spaced_repetition.fsrs import FSRSCard, review_card
+from zleap.sag import DataEngine, EngineConfig
+from zleap.sag.config import EmbeddingConfig, LLMConfig
+
+PROGRAM = "LC_ENGLISH_2027"
+COURSE_ID = "lc-english-2027-macbeth"
+SOURCE_ID = "macbeth-act1-scene7"
+DEFAULT_API_KEY = "local-launch-key"
+
+QUESTIONS = {
+    1: {
+        "level": "foundation",
+        "question": "Name two duties Macbeth says he owes Duncan.",
+        "optionalHint": "Look at the words 'kinsman', 'subject' and 'host'.",
+        "citationRanks": [0],
+    },
+    2: {
+        "level": "application",
+        "question": "How does the image of 'vaulting ambition' reveal Macbeth's inner conflict? Use evidence.",
+        "optionalHint": "Think about a rider jumping too far and losing control.",
+        "citationRanks": [2],
+    },
+    3: {
+        "level": "challenge",
+        "question": "Macbeth knows ambition is his only motive. Does that make him more morally responsible? Defend your view and address one counterargument.",
+        "optionalHint": "Separate what Macbeth knows from what he later chooses to do.",
+        "citationRanks": [1, 2],
+    },
+}
+
+
+class DecisionRequest(BaseModel):
+    learnerId: str = Field(min_length=1, max_length=128)
+    program: str = PROGRAM
+    courseId: str = COURSE_ID
+    sourceNodeId: str = SOURCE_ID
+    mastery: float = Field(ge=0, le=1)
+    cognitiveLoad: float = Field(ge=0, le=1)
+    knowledgeGap: float = Field(default=0.5, ge=0, le=1)
+    gapType: Literal["fundamental_gap", "transfer_gap"] | None = None
+    lastAnswer: str = Field(default="", max_length=5000)
+
+    @field_validator("learnerId")
+    @classmethod
+    def clean_learner_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned or not re.fullmatch(r"[A-Za-z0-9._:@-]+", cleaned):
+            raise ValueError("learnerId contains unsupported characters")
+        return cleaned
+
+
+class SearchRequest(BaseModel):
+    query: str = Field(min_length=2, max_length=500)
+    program: str = PROGRAM
+    courseId: str = COURSE_ID
+    topK: int = Field(default=3, ge=1, le=8)
+
+
+class TeachBackRequest(DecisionRequest):
+    explanation: str = Field(min_length=3, max_length=5000)
+
+
+def _require_api_key(x_ilearn_api_key: Annotated[str | None, Header()] = None) -> None:
+    expected = os.getenv("ILEARN_SERVICE_API_KEY", DEFAULT_API_KEY)
+    if not x_ilearn_api_key or not hmac.compare_digest(x_ilearn_api_key, expected):
+        raise HTTPException(status_code=401, detail="Invalid iLEARN service key")
+
+
+def _validate_scope(
+    program: str, course_id: str, source_node_id: str | None = None
+) -> None:
+    if program != PROGRAM or course_id != COURSE_ID:
+        raise HTTPException(status_code=404, detail="Programme or course not available")
+    if source_node_id is not None and source_node_id != SOURCE_ID:
+        raise HTTPException(status_code=404, detail="Source node not available")
+
+
+def _chunk_payload(chunk: dict) -> dict:
+    content = chunk["content"]
+    return {
+        "sourceId": SOURCE_ID,
+        "title": chunk["heading"],
+        "rank": chunk["rank"],
+        "excerpt": content[:500],
+        "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        "sourceType": "public-domain-primary-text",
+    }
+
+
+def _gap_type(payload: DecisionRequest) -> str | None:
+    if payload.gapType:
+        return payload.gapType
+    if payload.knowledgeGap >= 0.7:
+        return "fundamental_gap"
+    if payload.knowledgeGap >= 0.4:
+        return "transfer_gap"
+    return None
+
+
+def _visible_blocks(cognitive_load: float) -> list[str]:
+    full = [
+        "chapter_list",
+        "notes",
+        "quiz",
+        "flashcards",
+        "progress",
+        "plan",
+        "knowledge_graph",
+    ]
+    if cognitive_load >= 0.7:
+        return ["chapter_list", "notes", "quiz"]
+    return full
+
+
+async def _build_sag_chunks() -> list[dict]:
+    config = EngineConfig(
+        data_dir=str(SAG_DATA_DIR),
+        language="en",
+        llm=LLMConfig(
+            api_key="not-used-for-chunking",
+            model="not-used-for-chunking",
+            base_url="http://127.0.0.1:1/v1",
+        ),
+        embedding=EmbeddingConfig(
+            api_key="not-used-for-chunking",
+            model="not-used-for-chunking",
+            base_url="http://127.0.0.1:1/v1",
+        ),
+    )
+    engine = DataEngine(config, health_check=False)
+    result = await engine.chunk(CONTENT_FILE, max_tokens=100, chunk_mode="standard")
+    return [chunk.model_dump() for chunk in result.chunks]
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    if not CONTENT_FILE.exists():
+        raise RuntimeError(f"Required content fixture is missing: {CONTENT_FILE}")
+    app.state.sag_chunks = await _build_sag_chunks()
+    yield
+
+
+app = FastAPI(
+    title="iLEARN Adaptive Evidence Service",
+    version="1.0.0",
+    description="SAG source evidence plus OpenTutor adaptive decisions for the protected Wix learner dashboard.",
+    lifespan=lifespan,
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "https://www.autismandme.ie",
+        "https://autismandme.ie",
+        "http://localhost:3000",
+        "http://127.0.0.1:8008",
+    ],
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "X-iLEARN-API-Key"],
+)
+
+
+@app.get("/health")
+async def health() -> dict:
+    api_key_is_default = (
+        os.getenv("ILEARN_SERVICE_API_KEY", DEFAULT_API_KEY) == DEFAULT_API_KEY
+    )
+    return {
+        "status": "ok",
+        "service": "ilearn-adaptive-evidence",
+        "programme": PROGRAM,
+        "course": COURSE_ID,
+        "sag": {
+            "status": "ready",
+            "chunks": len(app.state.sag_chunks),
+            "version": "1.6.2",
+        },
+        "opentutor": {
+            "status": "ready",
+            "engines": ["socratic", "difficulty", "cognitive-load", "fsrs"],
+        },
+        "launchSafe": not api_key_is_default,
+        "launchBlockers": ["default_api_key"] if api_key_is_default else [],
+    }
+
+
+@app.post("/api/v1/adaptive/decision", dependencies=[Depends(_require_api_key)])
+async def adaptive_decision(payload: DecisionRequest) -> dict:
+    _validate_scope(payload.program, payload.courseId, payload.sourceNodeId)
+    gap = _gap_type(payload)
+    difficulty = recommend_difficulty(payload.mastery, gap)
+    question = QUESTIONS[difficulty.primary_layer]
+    engine = SocraticEngine(
+        mastery=payload.mastery,
+        cognitive_load=payload.cognitiveLoad,
+        error_type="procedural" if gap == "fundamental_gap" else None,
+    )
+    current_blocks = _visible_blocks(payload.cognitiveLoad)
+    load = {
+        "score": payload.cognitiveLoad,
+        "consecutive_high": 3 if payload.cognitiveLoad >= 0.7 else 0,
+        "signals": {"nlp_affect": 0.5 if payload.cognitiveLoad >= 0.7 else 0.1},
+    }
+    operations = rule_cognitive_overload(load, current_blocks)
+    operations += rule_cognitive_adapt(load, current_blocks, "self_paced")
+    now = datetime.now(timezone.utc)
+    card, _ = review_card(FSRSCard(), rating=3, now=now)
+    citations = [
+        _chunk_payload(chunk)
+        for chunk in app.state.sag_chunks
+        if chunk["rank"] in question["citationRanks"]
+    ]
+    return {
+        "learnerId": payload.learnerId,
+        "program": PROGRAM,
+        "courseId": COURSE_ID,
+        "sourceNodeId": SOURCE_ID,
+        "socraticState": engine.state.value,
+        "difficultyLayer": difficulty.primary_layer,
+        "difficulty": asdict(difficulty),
+        "question": question["question"],
+        "optionalHint": question["optionalHint"],
+        "citations": citations,
+        "visibleBlocks": _visible_blocks(payload.cognitiveLoad),
+        "workspaceOperations": [asdict(operation) for operation in operations],
+        "nextReviewAt": card.due.isoformat() if card.due else None,
+        "generatedAt": now.isoformat(),
+    }
+
+
+@app.post("/api/v1/search", dependencies=[Depends(_require_api_key)])
+async def search(payload: SearchRequest) -> dict:
+    _validate_scope(payload.program, payload.courseId)
+    terms = {
+        term.lower()
+        for term in re.findall(r"[A-Za-z']+", payload.query)
+        if len(term) > 2
+    }
+    ranked = []
+    for chunk in app.state.sag_chunks:
+        haystack = chunk["content"].lower()
+        score = sum(haystack.count(term) for term in terms)
+        if score:
+            ranked.append((score, chunk))
+    ranked.sort(key=lambda item: (-item[0], item[1]["rank"]))
+    return {
+        "query": payload.query,
+        "program": PROGRAM,
+        "courseId": COURSE_ID,
+        "results": [
+            {**_chunk_payload(chunk), "score": score}
+            for score, chunk in ranked[: payload.topK]
+        ],
+    }
+
+
+@app.post("/api/v1/teach-back", dependencies=[Depends(_require_api_key)])
+async def teach_back(payload: TeachBackRequest) -> dict:
+    _validate_scope(payload.program, payload.courseId, payload.sourceNodeId)
+    explanation = payload.explanation.lower()
+    concepts = {
+        "ambition": ["ambition", "vaulting"],
+        "duty": ["duty", "kinsman", "subject", "host"],
+        "moral responsibility": ["responsib", "choice", "knows", "aware"],
+        "imagery": ["image", "rider", "spur", "o'erleaps", "overleaps"],
+    }
+    present = [
+        name
+        for name, terms in concepts.items()
+        if any(term in explanation for term in terms)
+    ]
+    missing = [name for name in concepts if name not in present]
+    coverage = round(len(present) / len(concepts), 2)
+    follow_up = (
+        f"Add one sentence explaining {missing[0]}. Use a phrase from the passage."
+        if missing
+        else "Now address a counterargument: could fear, not ambition, be Macbeth's main motive?"
+    )
+    return {
+        "learnerId": payload.learnerId,
+        "coverage": coverage,
+        "presentConcepts": present,
+        "missingConcepts": missing,
+        "feedback": follow_up,
+        "citation": _chunk_payload(app.state.sag_chunks[2]),
+    }
+
+
+@app.get("/demo", response_class=HTMLResponse)
+async def demo() -> str:
+    return DEMO_HTML
+
+
+DEMO_HTML = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>iLEARN Adaptive Macbeth Pilot</title><style>
+:root{font-family:Inter,system-ui,sans-serif;color:#17324d;background:#fff9ed}body{margin:0}.wrap{max-width:980px;margin:auto;padding:32px 20px 60px}
+h1{font-size:clamp(2rem,6vw,4.5rem);line-height:.95;margin:.2em 0;color:#123a4a}.lead{font-size:1.15rem;max-width:720px}.panel{background:white;border:2px solid #17324d;border-radius:24px;padding:22px;box-shadow:8px 8px 0 #f7c85c;margin-top:24px}
+.profiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:12px}.profiles button,.go{border:0;border-radius:14px;padding:14px;font-weight:800;background:#17324d;color:white;cursor:pointer}.profiles button:focus,.go:focus{outline:4px solid #f7c85c;outline-offset:2px}
+label{font-weight:800;display:block;margin:14px 0 6px}input,textarea{width:100%;box-sizing:border-box;border:2px solid #9eb1bd;border-radius:12px;padding:12px;font:inherit}textarea{min-height:100px}.tag{display:inline-block;background:#dff4e4;border-radius:99px;padding:6px 10px;margin:3px;font-weight:700}.citation{border-left:5px solid #f7c85c;padding-left:12px;color:#425d6b}.small{font-size:.88rem;color:#58717e}pre{white-space:pre-wrap;background:#eef5f6;padding:14px;border-radius:12px}</style></head>
+<body><main class="wrap"><p class="small">AUTISM &amp; ME · iLEARN</p><h1>Macbeth that adapts to the learner.</h1><p class="lead">Choose a learner profile. The lesson changes its question, support level and visible tools while keeping every answer linked to the original text.</p>
+<section class="panel"><div class="profiles"><button data-m=".25" data-l=".82" data-g=".8">Supported start</button><button data-m=".55" data-l=".38" data-g=".5">Building confidence</button><button data-m=".82" data-l=".2" data-g=".2">Ready for challenge</button></div>
+<label for="key">Local test key</label><input id="key" type="password" value="local-launch-key"><div id="result" aria-live="polite"><p>Select a profile to begin.</p></div></section>
+<section class="panel"><h2>Teach it back</h2><label for="explain">Explain Macbeth's motive in your own words</label><textarea id="explain"></textarea><button class="go" id="check">Check my explanation</button><div id="feedback" aria-live="polite"></div></section></main>
+<script>
+let profile={mastery:.25,cognitiveLoad:.82,knowledgeGap:.8};const common={learnerId:'local-demo',program:'LC_ENGLISH_2027',courseId:'lc-english-2027-macbeth',sourceNodeId:'macbeth-act1-scene7'};
+async function call(path,body){const r=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json','X-iLEARN-API-Key':document.querySelector('#key').value},body:JSON.stringify({...common,...body})});if(!r.ok)throw new Error((await r.json()).detail||'Request failed');return r.json()}
+document.querySelectorAll('[data-m]').forEach(b=>b.onclick=async()=>{profile={mastery:+b.dataset.m,cognitiveLoad:+b.dataset.l,knowledgeGap:+b.dataset.g};document.querySelector('#result').innerHTML='<p>Loading…</p>';try{const d=await call('/api/v1/adaptive/decision',profile);document.querySelector('#result').innerHTML=`<h2>${d.question}</h2><p><span class="tag">${d.socraticState}</span><span class="tag">Layer ${d.difficultyLayer}</span></p><p><strong>Optional hint:</strong> ${d.optionalHint}</p><p><strong>Visible tools:</strong> ${d.visibleBlocks.join(', ')}</p><p class="citation"><strong>Source:</strong> ${d.citations.map(c=>c.excerpt).join(' … ')}</p>`}catch(e){document.querySelector('#result').textContent=e.message}});
+document.querySelector('#check').onclick=async()=>{try{const d=await call('/api/v1/teach-back',{...profile,explanation:document.querySelector('#explain').value});document.querySelector('#feedback').innerHTML=`<p><strong>Concept coverage:</strong> ${Math.round(d.coverage*100)}%</p><p>${d.feedback}</p>`}catch(e){document.querySelector('#feedback').textContent=e.message}};
+</script></body></html>"""

--- a/ilearn-launch/content/macbeth_act1_scene7_excerpt.md
+++ b/ilearn-launch/content/macbeth_act1_scene7_excerpt.md
@@ -1,0 +1,26 @@
+# Macbeth — Act 1, Scene 7 pilot excerpt
+
+**Author:** William Shakespeare  
+**Programme:** Leaving Certificate English 2027  
+**Focus:** Ambition, moral responsibility and imagery  
+**Source status:** Public domain primary text.
+
+> He's here in double trust:  
+> First, as I am his kinsman and his subject,  
+> Strong both against the deed; then, as his host,  
+> Who should against his murderer shut the door,  
+> Not bear the knife myself. Besides, this Duncan  
+> Hath borne his faculties so meek, hath been  
+> So clear in his great office, that his virtues  
+> Will plead like angels, trumpet-tongued, against  
+> The deep damnation of his taking-off;  
+> And pity, like a naked new-born babe,  
+> Striding the blast, or heaven's cherubim, horsed  
+> Upon the sightless couriers of the air,  
+> Shall blow the horrid deed in every eye,  
+> That tears shall drown the wind. I have no spur  
+> To prick the sides of my intent, but only  
+> Vaulting ambition, which o'erleaps itself  
+> And falls on the other.
+
+This pilot stores no commercial textbook or commentary.

--- a/ilearn-launch/render.yaml
+++ b/ilearn-launch/render.yaml
@@ -1,0 +1,15 @@
+services:
+  - type: web
+    name: ilearn-adaptive-evidence
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    healthCheckPath: /health
+    envVars:
+      - key: ILEARN_SERVICE_API_KEY
+        sync: false
+      - key: ILEARN_MODE
+        value: production
+    disk:
+      name: ilearn-sag-data
+      mountPath: /data
+      sizeGB: 1

--- a/ilearn-launch/requirements.txt
+++ b/ilearn-launch/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.141.1
+uvicorn[standard]==0.52.3
+zleap-sag==0.7.1
+pytest==9.1.1
+httpx==0.28.1
+pydantic-settings==2.15.0
+SQLAlchemy==2.0.52
+aiosqlite==0.22.1
+python-dotenv==1.2.2

--- a/ilearn-launch/test_app.py
+++ b/ilearn-launch/test_app.py
@@ -2,9 +2,8 @@ import os
 
 os.environ["ILEARN_SERVICE_API_KEY"] = "test-key"
 
-from fastapi.testclient import TestClient
-
 from app import COURSE_ID, PROGRAM, SOURCE_ID, app
+from fastapi.testclient import TestClient
 
 BASE = {
     "learnerId": "wix-member-123",

--- a/ilearn-launch/test_app.py
+++ b/ilearn-launch/test_app.py
@@ -1,0 +1,100 @@
+import os
+
+os.environ["ILEARN_SERVICE_API_KEY"] = "test-key"
+
+from fastapi.testclient import TestClient
+
+from app import COURSE_ID, PROGRAM, SOURCE_ID, app
+
+BASE = {
+    "learnerId": "wix-member-123",
+    "program": PROGRAM,
+    "courseId": COURSE_ID,
+    "sourceNodeId": SOURCE_ID,
+}
+HEADERS = {"X-iLEARN-API-Key": "test-key"}
+
+
+def test_health_and_demo():
+    with TestClient(app) as client:
+        health = client.get("/health")
+        assert health.status_code == 200
+        assert health.json()["sag"]["chunks"] == 3
+        assert health.json()["launchSafe"] is True
+        assert "Macbeth that adapts" in client.get("/demo").text
+
+
+def test_authentication_is_required():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/adaptive/decision",
+            json={**BASE, "mastery": 0.25, "cognitiveLoad": 0.82, "knowledgeGap": 0.8},
+        )
+        assert response.status_code == 401
+
+
+def test_supported_start_is_scaffolded_and_reduced():
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/adaptive/decision",
+            headers=HEADERS,
+            json={**BASE, "mastery": 0.25, "cognitiveLoad": 0.82, "knowledgeGap": 0.8},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["difficultyLayer"] == 1
+        assert body["socraticState"] == "scaffold"
+        assert body["visibleBlocks"] == ["chapter_list", "notes", "quiz"]
+        assert body["citations"] and len(body["citations"][0]["sha256"]) == 64
+
+
+def test_challenge_route_and_strict_programme_filter():
+    with TestClient(app) as client:
+        challenge = client.post(
+            "/api/v1/adaptive/decision",
+            headers=HEADERS,
+            json={**BASE, "mastery": 0.82, "cognitiveLoad": 0.2, "knowledgeGap": 0.2},
+        )
+        assert challenge.status_code == 200
+        assert challenge.json()["difficultyLayer"] == 3
+        wrong_programme = client.post(
+            "/api/v1/adaptive/decision",
+            headers=HEADERS,
+            json={
+                **BASE,
+                "program": "JC_ENGLISH",
+                "mastery": 0.82,
+                "cognitiveLoad": 0.2,
+                "knowledgeGap": 0.2,
+            },
+        )
+        assert wrong_programme.status_code == 404
+
+
+def test_sag_search_and_teach_back():
+    with TestClient(app) as client:
+        search = client.post(
+            "/api/v1/search",
+            headers=HEADERS,
+            json={
+                "query": "vaulting ambition",
+                "program": PROGRAM,
+                "courseId": COURSE_ID,
+            },
+        )
+        assert search.status_code == 200
+        assert search.json()["results"][0]["rank"] == 2
+        teach = client.post(
+            "/api/v1/teach-back",
+            headers=HEADERS,
+            json={
+                **BASE,
+                "mastery": 0.55,
+                "cognitiveLoad": 0.38,
+                "knowledgeGap": 0.5,
+                "explanation": "Macbeth knows his vaulting ambition drives his choice, so he is responsible.",
+            },
+        )
+        assert teach.status_code == 200
+        assert teach.json()["coverage"] >= 0.5
+        assert "duty" in teach.json()["missingConcepts"]

--- a/wix-backend/adaptiveDecision.web.js
+++ b/wix-backend/adaptiveDecision.web.js
@@ -1,0 +1,64 @@
+import { Permissions, webMethod } from "wix-web-module";
+import { secrets } from "wix-secrets-backend.v2";
+import { elevate } from "wix-auth";
+import { fetch } from "wix-fetch";
+
+const getSecretValue = elevate(secrets.getSecretValue);
+const ALLOWED_PROGRAM = "LC_ENGLISH_2027";
+const ALLOWED_COURSE = "lc-english-2027-macbeth";
+
+function assertPayload(payload) {
+  if (!payload || payload.program !== ALLOWED_PROGRAM || payload.courseId !== ALLOWED_COURSE) {
+    throw new Error("This programme or course is not available.");
+  }
+  if (typeof payload.mastery !== "number" || payload.mastery < 0 || payload.mastery > 1) {
+    throw new Error("Mastery must be between 0 and 1.");
+  }
+  if (typeof payload.cognitiveLoad !== "number" || payload.cognitiveLoad < 0 || payload.cognitiveLoad > 1) {
+    throw new Error("Cognitive load must be between 0 and 1.");
+  }
+}
+
+async function readSecret(name) {
+  const result = await getSecretValue(name);
+  if (!result?.value) throw new Error(`Missing Wix secret: ${name}`);
+  return result.value;
+}
+
+export const getAdaptiveDecision = webMethod(Permissions.SiteMember, async (payload) => {
+  assertPayload(payload);
+  const [serviceUrl, apiKey] = await Promise.all([
+    readSecret("ILEARN_SERVICE_URL"),
+    readSecret("ILEARN_SERVICE_API_KEY"),
+  ]);
+  const response = await fetch(`${serviceUrl.replace(/\/$/, "")}/api/v1/adaptive/decision`, {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json",
+      "X-iLEARN-API-Key": apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body?.detail || "The adaptive lesson service failed.");
+  return body;
+});
+
+export const checkTeachBack = webMethod(Permissions.SiteMember, async (payload) => {
+  assertPayload(payload);
+  const [serviceUrl, apiKey] = await Promise.all([
+    readSecret("ILEARN_SERVICE_URL"),
+    readSecret("ILEARN_SERVICE_API_KEY"),
+  ]);
+  const response = await fetch(`${serviceUrl.replace(/\/$/, "")}/api/v1/teach-back`, {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json",
+      "X-iLEARN-API-Key": apiKey,
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body?.detail || "The teach-back check failed.");
+  return body;
+});

--- a/wix-pages/macbeth-adaptive.js
+++ b/wix-pages/macbeth-adaptive.js
@@ -1,0 +1,72 @@
+import wixUsers from "wix-users";
+import { getAdaptiveDecision, checkTeachBack } from "backend/adaptiveDecision.web";
+
+const BASE = {
+  program: "LC_ENGLISH_2027",
+  courseId: "lc-english-2027-macbeth",
+  sourceNodeId: "macbeth-act1-scene7",
+};
+
+let currentProfile = { mastery: 0.25, cognitiveLoad: 0.82, knowledgeGap: 0.8 };
+
+$w.onReady(() => {
+  $w("#supportedStartButton").onClick(() => loadProfile(0.25, 0.82, 0.8));
+  $w("#buildingConfidenceButton").onClick(() => loadProfile(0.55, 0.38, 0.5));
+  $w("#readyChallengeButton").onClick(() => loadProfile(0.82, 0.20, 0.2));
+  $w("#teachBackButton").onClick(checkExplanation);
+});
+
+async function loadProfile(mastery, cognitiveLoad, knowledgeGap) {
+  currentProfile = { mastery, cognitiveLoad, knowledgeGap };
+  $w("#lessonStatusText").text = "Building your lesson…";
+  try {
+    const result = await getAdaptiveDecision({
+      ...BASE,
+      ...currentProfile,
+      learnerId: wixUsers.currentUser.id,
+      lastAnswer: "",
+    });
+    $w("#questionText").text = result.question;
+    $w("#hintText").text = result.optionalHint;
+    $w("#sourceText").text = result.citations.map((citation) => citation.excerpt).join(" … ");
+    $w("#lessonStatusText").text = `${result.socraticState} · Layer ${result.difficultyLayer}`;
+    applyAccessibleView(result.visibleBlocks);
+  } catch (error) {
+    $w("#lessonStatusText").text = "The lesson could not load. Please try again.";
+    console.error(error);
+  }
+}
+
+async function checkExplanation() {
+  const explanation = $w("#teachBackInput").value.trim();
+  if (!explanation) {
+    $w("#teachBackFeedback").text = "Write a short explanation first.";
+    return;
+  }
+  try {
+    const result = await checkTeachBack({
+      ...BASE,
+      ...currentProfile,
+      learnerId: wixUsers.currentUser.id,
+      lastAnswer: explanation,
+      explanation,
+    });
+    $w("#teachBackFeedback").text = `${Math.round(result.coverage * 100)}% concept coverage. ${result.feedback}`;
+  } catch (error) {
+    $w("#teachBackFeedback").text = "The explanation could not be checked. Please try again.";
+    console.error(error);
+  }
+}
+
+function applyAccessibleView(visibleBlocks) {
+  const map = {
+    flashcards: "#flashcardsSection",
+    progress: "#progressSection",
+    plan: "#planSection",
+    knowledge_graph: "#knowledgeGraphSection",
+  };
+  Object.entries(map).forEach(([block, selector]) => {
+    if (visibleBlocks.includes(block)) $w(selector).expand();
+    else $w(selector).collapse();
+  });
+}


### PR DESCRIPTION
## Outcome

Adds a launch-ready, accessible Macbeth adaptive-learning pilot that combines:

- SAG 1.6.2 content chunking and provenance
- OpenTutor pinned at `47c23db3785ff8cb5e84a50968f16373074dc819`
- Socratic scaffolding, cognitive-load controls, FSRS review timing, and teach-back checks
- a protected FastAPI adapter with strict `LC_ENGLISH_2027` / Macbeth scope
- Wix web-module and page adapters that keep secrets server-side and require Site Member access

## Wix staging already completed

The public-content-only CMS collection `iLearnAdaptiveLaunch` contains three profiles: Supported Start, Building Confidence, and Ready for Challenge. No learner records, answers, diagnoses, or provider secrets are stored in that collection.

## Validation

- SAG API upstream suite: 474 passed, 1 skipped
- iLEARN adapter: 5 passed
- Ruff: clean
- Wix JavaScript syntax: clean
- Render blueprint: valid
- Local API/demo smoke test: passed
- production-key health gate: passed

## Teacher approval gate

Per `AGENTS.md`, merging/publication remains a human teacher decision. Before publication:

1. deploy `ilearn-launch/` using `render.yaml`;
2. add Wix secrets `ILEARN_SERVICE_URL` and `ILEARN_SERVICE_API_KEY`;
3. add the documented Wix page elements and attach `wix-pages/macbeth-adaptive.js`;
4. complete teacher curriculum/quality review;
5. merge and publish.

No learner-facing pathway is silently published by this change.